### PR TITLE
app/styles/hack.css, .hackfolder .index > ul add padding for scrolling bar

### DIFF
--- a/app/styles/hack.sass
+++ b/app/styles/hack.sass
@@ -49,7 +49,7 @@ a
   .index
     margin: 14px 0px 10px 0px
     cursor: w-resize
-    width: 200px
+    width: 210px
     +transition(margin-left 0.5s)
     &.collapsed
       margin-left: -184px
@@ -82,6 +82,8 @@ a
         a
           color: #09f
 
+    > ul
+      padding: 5px
     ul
       margin: 0
       li


### PR DESCRIPTION
Add 10px in .hackfolder .index width and padding 5px in .hackfolder .index > ul.
It can prevent scrolling bar and arrow sign overlapping.
