### PR TITLE
match videoId of ustream without query string

### DIFF
--- a/app/app/controllers.ls
+++ b/app/app/controllers.ls
@@ -302,7 +302,7 @@ angular.module 'app.controllers' <[ui.state ngCookies]>
           response <~ request.execute()
           if 'live' == response.items?[0].snippet.liveBroadcastContent
             it.tags ++= {class: 'warning', content: 'LIVE'}
-        else if videoToken = it.url.match(/ustream.tv\/embed\/([^?]*).*/)
+        else if videoToken = it.url.match(/ustream.tv\/embed\/([^?]+)/)
           videoId = videoToken[1]
           response <- $.get ("http://query.yahooapis.com/v1/public/yql?q=select%20*%20from%20html%20where%20url%3D'http%3A%2F%2Fapi.ustream.tv%2Fjson%2Fchannel%2F" + videoId + "%2FgetValueOf%2Fstatus'&format=json&diagnostics=true&callback=")
           if 'live' == JSON.parse(response.query?.results?.body?.p).results


### PR DESCRIPTION
Match videoId of ustream without query string.

This patch can avoid mis-match videoId of ustream embed url like:
http://www.ustream.tv/embed/videoId?v=3&wmode=direct
