### PR TITLE
#73 Change favicon service from http://g.etfv.co/ (broken) to https:/…

### DIFF
--- a/app/app/controllers.ls
+++ b/app/app/controllers.ls
@@ -347,16 +347,16 @@ angular.module 'app.controllers' <[ui.router ngCookies]>
             type: \video
             provider: \youtube
             id: that.1
-            icon: "http://g.etfv.co/#{ url }"
+            icon: "https://www.google.com/s2/favicons?domain=#{ url }"
         | // https?:\/\/(?:www\.)?ustream\.tv/(?:embed|channel)/([-\w]+) //
             type: \video
             provider: \ustream
             id: that.1
-            icon: "http://g.etfv.co/#{ url }"
+            icon: "https://www.google.com/s2/favicons?domain=#{ url }"
         | // ^(https?:\/\/[^/]+) //
             type: \url
             id: encodeURIComponent encodeURIComponent url
-            icon: "http://g.etfv.co/#{ that.1 }"
+            icon: "https://www.google.com/s2/favicons?domain=#{ that.1 }"
         | otherwise => console?log \unrecognized url
 
         if entry.type is \dummy and !entry.title?length

--- a/templates/controllers.ls
+++ b/templates/controllers.ls
@@ -296,16 +296,17 @@ angular.module 'app.controllers' <[ui.state ngCookies]>
             type: \video
             provider: \youtube
             id: that.1
-            icon: "http://g.etfv.co/#{ url }"
+            icon: "https://www.google.com/s2/favicons?domain=#{ url }"
         | // https?:\/\/(?:www\.)?ustream\.tv/(?:embed|channel)/([-\w]+) //
             type: \video
             provider: \ustream
+
             id: that.1
-            icon: "http://g.etfv.co/#{ url }"
+            icon: "https://www.google.com/s2/favicons?domain=#{ url }"
         | // ^(https?:\/\/[^/]+) //
             type: \url
             id: encodeURIComponent encodeURIComponent url
-            icon: "http://g.etfv.co/#{ that.1 }"
+            icon: "https://www.google.com/s2/favicons?domain=#{ that.1 }"
         | otherwise => console?log \unrecognized url
 
         if entry.type is \dummy and !entry.title?length


### PR DESCRIPTION
Refer to http://stackoverflow.com/questions/22842262/an-alternative-for-http-g-etfv-co-url-favicon-services

Before 
<img width="298" alt="2015-09-17 8 57 19" src="https://cloud.githubusercontent.com/assets/1414712/9933640/c9b5aeaa-5d7e-11e5-91df-afb6694f3b31.png">

After
<img width="298" alt="2015-09-17 8 57 30" src="https://cloud.githubusercontent.com/assets/1414712/9933643/cfb17da2-5d7e-11e5-92f1-78cd4899e1ff.png">
